### PR TITLE
fix duplicates in many requests generation

### DIFF
--- a/src/mock-api/factories/requestFactory.ts
+++ b/src/mock-api/factories/requestFactory.ts
@@ -1,4 +1,5 @@
 import faker from '@faker-js/faker'
+import { eachDayOfInterval } from 'date-fns'
 import { Factory } from 'miragejs'
 import { DayOffRequest } from 'mock-api/models'
 import { isWorkingDay } from 'poland-public-holidays'
@@ -42,11 +43,10 @@ export const requestFactory = Factory.extend(genRandomDayOffRequest())
 export const genManyRequests = (count: number) => {
   const requests: Omit<DayOffRequest, 'id'>[] = []
   const drawnDayoffInAlreadyScehduledTime = (req: Omit<DayOffRequest, 'id'>) =>
-    requests.some(
-      (existingReq) =>
-        isDateBetween(req.startDate, existingReq.startDate, existingReq.endDate) ||
-        isDateBetween(req.endDate, existingReq.startDate, existingReq.endDate)
-    )
+    requests.some((existingReq) => {
+      const days = eachDayOfInterval({ start: new Date(req.startDate), end: new Date(req.endDate) })
+      return days.some((day) => isDateBetween(day, existingReq.startDate, existingReq.endDate))
+    })
   for (let i = 0; i < count; i++) {
     let req = genRandomDayOffRequest()
 


### PR DESCRIPTION
There is an issue with the genManyRequests function, that the requests are getting drawn in already scheduled period. This PR attempts to fix this, I will try to write some unit tests on Monday.