### PR TITLE
Fix modal not swiping down

### DIFF
--- a/src/screens/editProfile/EditProfile.tsx
+++ b/src/screens/editProfile/EditProfile.tsx
@@ -20,7 +20,6 @@ import { ProfileDetails } from './components/ProfileDetails'
 import { TeamSubscriptions } from './components/TeamSubscriptions'
 import { ProfileColor } from './components/ProfileColor'
 import { SaveChangesButton } from './components/SaveChangesButton'
-import { backgroundColor } from '@shopify/restyle'
 
 type EditDetailsTypes = Pick<User, 'lastName' | 'firstName' | 'occupation' | 'photo' | 'userColor'>
 


### PR DESCRIPTION
The gesture responder in edit profile section didn't propagate the swipe gesture down into the tree, so modals wrapped with it were not swipeable.