### PR TITLE
speed up logout navigating to onboarding

### DIFF
--- a/src/contexts/UserProvider.tsx
+++ b/src/contexts/UserProvider.tsx
@@ -38,6 +38,13 @@ export const UserContextProvider = ({ children }: ProviderProps) => {
     []
   )
   const handleLogout = async () => {
+    setUser(null)
+    delete axios.defaults.headers.common.userId
+    clearUserCache()
+    queryClient.invalidateQueries(QueryKeys.NOTIFICATIONS)
+    queryClient.invalidateQueries(QueryKeys.USER_REQUESTS)
+    queryClient.invalidateQueries(QueryKeys.USER_STATS)
+    queryClient.invalidateQueries(QueryKeys.ORGANIZATION)
     await removeMany([
       'firstName',
       'lastName',
@@ -46,13 +53,6 @@ export const UserContextProvider = ({ children }: ProviderProps) => {
       'userColor',
       'seenNotificationsIds',
     ])
-    delete axios.defaults.headers.common.userId
-    setUser(null)
-    clearUserCache()
-    queryClient.invalidateQueries(QueryKeys.NOTIFICATIONS)
-    queryClient.invalidateQueries(QueryKeys.USER_REQUESTS)
-    queryClient.invalidateQueries(QueryKeys.USER_STATS)
-    queryClient.invalidateQueries(QueryKeys.ORGANIZATION)
   }
 
   const value: ContextProps = {


### PR DESCRIPTION
Setting user as null before removing user data from async storage, so we're already navigated to onboarding when localStorage util is wiping out user data