### PR TITLE
optimize month change

### DIFF
--- a/src/components/CalendarComponents/CalendarDay.tsx
+++ b/src/components/CalendarComponents/CalendarDay.tsx
@@ -1,3 +1,4 @@
+import { useCalendarPeriodStyles } from 'hooks/useCalendarStyles'
 import React from 'react'
 import { Box } from 'utils/theme'
 import { CalendarDayDots } from './CalendarDayDots'
@@ -6,9 +7,12 @@ import { NewDayComponentProps } from './CalendarTypes'
 
 export const CalendarDay = (
   p: NewDayComponentProps & MarkingStyles & { ignoreDarkMode?: true }
-) => (
-  <Box alignItems="center" position="relative">
-    <CalendarDayMain {...p} />
-    <CalendarDayDots marking={p.marking} />
-  </Box>
-)
+) => {
+  const { validPeriodStyles } = useCalendarPeriodStyles()
+  return (
+    <Box alignItems="center" position="relative">
+      <CalendarDayMain {...p} styles={p.styles ?? validPeriodStyles} />
+      <CalendarDayDots marking={p.marking} />
+    </Box>
+  )
+}

--- a/src/components/ExpandableCalendar.tsx
+++ b/src/components/ExpandableCalendar.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useCallback } from 'react'
+import React, { useRef, useEffect, useMemo } from 'react'
 import { Box, useTheme } from 'utils/theme'
 import { CalendarProps as RNCalendarProps, DateObject, LocaleConfig } from 'react-native-calendars'
 import CalendarHeader from 'react-native-calendars/src/calendar/header'
@@ -25,14 +25,13 @@ import { isIos } from 'utils/layout'
 import { addMonths, addWeeks } from 'date-fns'
 import { startOfMonth, startOfWeek } from 'date-fns/esm'
 import { useLanguage } from 'hooks/useLanguage'
-import { useCalendarPeriodStyles } from 'hooks/useCalendarStyles'
 import { isScreenHeightShort } from 'utils/deviceSizes'
 import { doesMonthInCalendarHasSixRows } from 'utils/doesMonthInCalendarHasSixRows'
 import { CalendarHeader as CalendarHeaderComponent } from './CalendarComponents/CalendarHeader'
 import { CalendarDay } from './CalendarComponents/CalendarDay'
 import { calendarTheme, headerTheme } from './CalendarComponents/ExplandableCalendarTheme'
 import { WeekCalendar } from './CalendarComponents/WeekCalendar'
-import { CalendarRef, NewDayComponentProps } from './CalendarComponents/CalendarTypes'
+import { CalendarRef } from './CalendarComponents/CalendarTypes'
 import { NewCalendar } from './CalendarComponents/NewCalendar'
 
 type MonthChangeEventType = ACTION_DATE_SET | ACTION_DISMISSED
@@ -62,7 +61,7 @@ export const ExpandableCalendar = (props: ExpandableCalendarProps & RNCalendarPr
   const opacity = useDerivedValue(() =>
     containerHeight.value > WEEK_CALENDAR_HEIGHT ? withTiming(1) : withTiming(0)
   )
-  const { validPeriodStyles } = useCalendarPeriodStyles()
+
   const handlePicker = (event: MonthChangeEventType, newDate: Date) => {
     hidePicker()
     if (event === ACTION_DATE_SET) setSelectedDate(newDate)
@@ -133,6 +132,14 @@ export const ExpandableCalendar = (props: ExpandableCalendarProps & RNCalendarPr
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  const newMarkedDates = useMemo(
+    () =>
+      deepmerge(markedDates, {
+        [getISODateString(selectedDate)]: { selected: true },
+      }),
+    [markedDates, selectedDate]
+  )
+
   return (
     <>
       <PanGestureHandler onGestureEvent={gestureHandler}>
@@ -190,17 +197,8 @@ export const ExpandableCalendar = (props: ExpandableCalendarProps & RNCalendarPr
                 hideExtraDays
                 firstDay={1}
                 theme={calendarTheme}
-                // FIXME: NewCalendar type in CalendarTypes differs from Calendar type defined in react-native-calendars, probably purposely,
-                // but NewCalendar component or the CalendarDay component don't have a type guard to let their props differ, and so runtime type-errors may occur
-                dayComponent={useCallback<F1<NewDayComponentProps>>(
-                  (props) => (
-                    <CalendarDay {...props} styles={validPeriodStyles} />
-                  ),
-                  [validPeriodStyles]
-                )}
-                markedDates={deepmerge(markedDates, {
-                  [getISODateString(selectedDate)]: { selected: true },
-                })}
+                dayComponent={CalendarDay}
+                markedDates={newMarkedDates}
                 markingType="multi-dot"
                 disableMonthChange
                 ref={calendarRef}

--- a/src/screens/calendar/Calendar.tsx
+++ b/src/screens/calendar/Calendar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { Box } from 'utils/theme'
 import { EventsList } from 'screens/calendar/components/EventsList'
@@ -23,19 +23,26 @@ const CalendarToWrap = () => {
     currentMonthDays,
   } = useCalendarData()
 
-  const handleDayPress = ({ dateString }: { dateString: string }) => {
-    const dayEvents = currentMonthDays.find((a) => a.date === dateString)
-    if (!dayEvents) return
-    const index = currentMonthDays.indexOf(dayEvents)
-    flatListRef.current?.scrollToIndex({ index, animated: true })
-    setTimeout(() => setSelectedDate(parseISO(dateString)))
-  }
+  const handleDayPress = useCallback(
+    ({ dateString }: { dateString: string }) => {
+      const dayEvents = currentMonthDays.find((a) => a.date === dateString)
+      if (!dayEvents) return
+      const index = currentMonthDays.indexOf(dayEvents)
+      flatListRef.current?.scrollToIndex({ index, animated: true })
+      setTimeout(() => setSelectedDate(parseISO(dateString)))
+    },
+    [currentMonthDays, setSelectedDate]
+  )
 
   // Comment: show loader spinner while calendar is rendering
   const [isLoading, { setFalse: hideLoader }] = useBooleanState(true)
+
   useEffect(() => {
     hideLoader()
   }, [hideLoader])
+
+  const markedDates = useMemo(() => getMarkedDates(currentMonthDays), [currentMonthDays])
+
   if (isLoading) return <LoadingModal show />
 
   return (
@@ -55,7 +62,7 @@ const CalendarToWrap = () => {
         shadowRadius={6}
         elevation={4}>
         <ExpandableCalendar
-          markedDates={getMarkedDates(currentMonthDays)}
+          markedDates={markedDates}
           markingType="multi-dot"
           selectedDate={selectedDate}
           setSelectedDate={setSelectedDate}


### PR DESCRIPTION
the calendar didn't get much faster, React.memo used on day component doesn't help at all. I've just memoized some values that caused calendar days to render more frequently than they need to.