### PR TITLE
Fix/ add "git push" to CD workflows & bump version in package.json

### DIFF
--- a/.github/workflows/android-build-deploy.yml
+++ b/.github/workflows/android-build-deploy.yml
@@ -50,3 +50,4 @@ jobs:
           git add  ./fastlane/report.xml
           git add ./android/app/build.gradle
           git commit -m "bump ANDROID to version $PACKAGE_VERSION"
+          git push

--- a/.github/workflows/android-build-deploy.yml
+++ b/.github/workflows/android-build-deploy.yml
@@ -46,6 +46,7 @@ jobs:
           PACKAGE_VERSION=$(sed -nr 's/^\s*\"version": "([0-9]{1,}\.[0-9]{1,}.*)",$/\1/p' package.json)
           git config --global user.name 'jan-kozinski'
           git config --global user.email 'jan-kozinski@users.noreply.github.com'
+          git checkout -b release/ios-$PACKAGE_VERSION
           git add ./package.json
           git add  ./fastlane/report.xml
           git add ./android/app/build.gradle

--- a/.github/workflows/apple_app_store_publish.yml
+++ b/.github/workflows/apple_app_store_publish.yml
@@ -65,3 +65,4 @@ jobs:
           git add ./ios/Holidayly/Info.plist
           git add ./ios/OneSignalNotificationServiceExtension/Info.plist
           git commit -m "bump iOS to version $PACKAGE_VERSION"
+          git push

--- a/.github/workflows/apple_app_store_publish.yml
+++ b/.github/workflows/apple_app_store_publish.yml
@@ -1,5 +1,4 @@
 name: PRODUCTION | Publish to Apple Store
-
 on:
   workflow_dispatch:
     inputs:
@@ -59,6 +58,7 @@ jobs:
           PACKAGE_VERSION=$(sed -nr 's/^\s*\"version": "([0-9]{1,}\.[0-9]{1,}.*)",$/\1/p' package.json)
           git config --global user.name 'jan-kozinski'
           git config --global user.email 'jan-kozinski@users.noreply.github.com'
+          git checkout -b release/ios-$PACKAGE_VERSION
           git add ./package.json
           git add  ./fastlane/report.xml
           git add ./ios/Holidayly.xcodeproj/project.pbxproj

--- a/.github/workflows/apple_testflight_publish.yml
+++ b/.github/workflows/apple_testflight_publish.yml
@@ -65,3 +65,4 @@ jobs:
           git add ./ios/Holidayly/Info.plist
           git add ./ios/OneSignalNotificationServiceExtension/Info.plist
           git commit -m "bump iOS to version $PACKAGE_VERSION"
+          git push

--- a/.github/workflows/apple_testflight_publish.yml
+++ b/.github/workflows/apple_testflight_publish.yml
@@ -1,5 +1,4 @@
 name: TESTFLIGHT | Publish to Apple Store
-
 on:
   workflow_dispatch:
     inputs:
@@ -59,6 +58,7 @@ jobs:
           PACKAGE_VERSION=$(sed -nr 's/^\s*\"version": "([0-9]{1,}\.[0-9]{1,}.*)",$/\1/p' package.json)
           git config --global user.name 'jan-kozinski'
           git config --global user.email 'jan-kozinski@users.noreply.github.com'
+          git checkout -b release/ios-$PACKAGE_VERSION
           git add ./package.json
           git add  ./fastlane/report.xml
           git add ./ios/Holidayly.xcodeproj/project.pbxproj

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -154,8 +154,8 @@ android {
         applicationId "com.holidaily"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 60
-        versionName "1.0.55"
+        versionCode 61
+        versionName "1.0.56"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
         if (isNewArchitectureEnabled()) {
             // We configure the CMake build only if you decide to opt-in for the New Architecture.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Holidaily",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
Looks that the "Android build-deploy" workflow triggered today by @iceu-bb didn't commit the version bump like it should. This PR attempts to fix the workflow