### PR TITLE
chore: bumped compile, target and build tools versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "31.0.0"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 23
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 33
+        targetSdkVersion = 33
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
             ndkVersion = "24.0.8215888"


### PR DESCRIPTION
I did this because we've got a message from Google saying:
"To continue making updates to your app, ensure your app targets Android 13 (API level 33)."